### PR TITLE
Build - note on maven 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,9 @@
       <email>lijun.liao@gmail.com</email>
     </developer>
   </developers>
+  <prerequisites>
+    <maven>3.0.5</maven>
+  </prerequisites>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <servlet.version>3.1.0</servlet.version>


### PR DESCRIPTION
`<prerequisites>` is not actually the correct way to specify minimal maven version, but this already decreases output e.g. of `mvn versions:display-plugin-updates` #62 

> [WARNING] The project org.xipki:xipki-parent:pom:3.1.0-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html

However this is the most readable for humans, and should state, that you don't need to have maven 2.x supported for build.

