### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ follows.
   ```
  
   Then you will find the following binaries:
-   - DB Tool: `assembles/xipki-dbtool/target/xipki-dbtool-<version>.zip`
-   - CA: `assembles/xipki-ca/target/xipki-ca-<version>.zip`
-   - OCSP: `assembles/xipki-ocsp/target/xipki-ocsp-<version>.zip`
-   - CLI (Command Line Interface): `assembles/xipki-cli/target/xipki-cli-<version>.tar.gz` (or `xipki-cli-<version>-jdk8.tar.gz` for JDK 8)
+   - DB Tool: `assemblies/xipki-dbtool/target/xipki-dbtool-<version>.zip`
+   - CA: `assemblies/xipki-ca/target/xipki-ca-<version>.zip`
+   - OCSP: `assemblies/xipki-ocsp/target/xipki-ocsp-<version>.zip`
+   - CLI (Command Line Interface): `assemblies/xipki-cli/target/xipki-cli-<version>.tar.gz` (or `xipki-cli-<version>-jdk8.tar.gz` for JDK 8)
 
 ## Install DB Tool
 


### PR DESCRIPTION
Modified README.md to cloned directory structure.

ubuntu@ubuntu:~/xipki$ ls assembles/xipki-ca/target/
ls: cannot access 'assembles/xipki-ca/target/': No such file or directory
ubuntu@ubuntu:~/xipki$ ls assemblies/xipki-ca/target/
archive-tmp  bin  dependency-maven-plugin-markers  lib  webapps  xipki  xipki-ca-5.4.0-SNAPSHOT.zip