### PR TITLE
Fixed custom store class not loadable

### DIFF
--- a/ocsp-server/src/main/java/org/xipki/ocsp/server/OcspServerUtil.java
+++ b/ocsp-server/src/main/java/org/xipki/ocsp/server/OcspServerUtil.java
@@ -150,7 +150,7 @@ public class OcspServerUtil {
       } else if (STORE_TYPE_EJBCA_DB.equals(type)) {
         store = new EjbcaCertStatusStore();
       } else if (type.startsWith("java:")) {
-        String className = type.substring("java:".length()).trim();
+        String className = conf.getSource().getType().substring("java:".length()).trim();
         try {
           Class<?> clazz = Class.forName(className, false, OcspServerUtil.class.getClassLoader());
           store = (OcspStore) clazz.getDeclaredConstructor().newInstance();


### PR DESCRIPTION
Fixed the loading of a custom class for the `OcspStorage`.

This failed, because the config param value in `type` was converted to lower case due to the code for checking it's type against other storage types.

Fixed by taking original config value and extracting class name from it; which than has the capital letters for the ususal camel case notation in Java.

Workaround with current library is to name the class of the `OcspStorage` all in lower name, e.g. `org.example.dummystore` .


Let me know if this PR needs to be in a different format.