### PR TITLE
Fixed health check in 'OcspServerImpl'

### DIFF
--- a/ocsp-server/src/main/java/org/xipki/ocsp/server/OcspServerImpl.java
+++ b/ocsp-server/src/main/java/org/xipki/ocsp/server/OcspServerImpl.java
@@ -1026,7 +1026,7 @@ public class OcspServerImpl implements OcspServer {
 
     for (OcspStore store : responder.getStores()) {
       boolean storeHealthy = store.isHealthy();
-      if (storeHealthy) {
+      if (!storeHealthy) {
         return false;
       }
     }

--- a/ocsp-server/src/main/java/org/xipki/ocsp/server/store/DbCertStatusStore.java
+++ b/ocsp-server/src/main/java/org/xipki/ocsp/server/store/DbCertStatusStore.java
@@ -127,7 +127,7 @@ public class DbCertStatusStore extends OcspStore {
           try {
             wait(1000);
           } catch (InterruptedException ex) {
-            LOG.warn("interrputed, continue waiting");
+            LOG.warn("interrupted, continue waiting");
           }
         }
       }


### PR DESCRIPTION
Health check logic is probably wrong: It should state healthy in case that all responder stores are healthy (and the signer).

Current logic is, e.g., stating "healthy" in case that all responder stores are **not** healthy, so broken.