### PR TITLE
Update sentenv.sh

### DIFF
--- a/assemblies/shared/conf/bin/setenv.sh
+++ b/assemblies/shared/conf/bin/setenv.sh
@@ -1,2 +1,13 @@
-export JAVA_OPTS="${JAVA_OPTS} -DXIPKI_BASE=${CATALINA_HOME}/xipki"
+# Try to guess where xipki conf is
+if [ -d ${CATALINA_HOME}/xipki ] ; then
+	# try first the CATALINA_HOME - original
+	export JAVA_OPTS="${JAVA_OPTS} -DXIPKI_BASE=${CATALINA_HOME}/xipki"
+elif [ -d ${CATALINA_BASE}/xipki ] ; then
+	# try the CATALINA_BASE (usual setup on debian/ubuntu)
+	export JAVA_OPTS="${JAVA_OPTS} -DXIPKI_BASE=${CATALINA_BASE}/xipki"
+else
+	# Finally fall back to CATALINA_HOME (source install)
+	export JAVA_OPTS="${JAVA_OPTS} -DXIPKI_BASE=${CATALINA_HOME}/xipki"
+fi
+
 export JDK_JAVA_OPTIONS="${JDK_JAVA_OPTIONS} --add-exports=jdk.crypto.cryptoki/sun.security.pkcs11.wrapper=ALL-UNNAMED"


### PR DESCRIPTION
Fixes https://github.com/xipki/xipki/issues/267

Due to config not being found default tomcat9 on ubuntu/debian will fail to start the CA application and mislead to the source of the error.

The proposed bugfix tries to set the config a bit harder, by validating if a xipki (conf) dir exists in CATALINA_HOME and CATALINA_BASE. To keep the old behaviour if both are not found defaults to `CATALINA_HOME`