### PR TITLE
Fixing `servletPaths` sorting in `OcspServerImpl`

### DIFF
--- a/ocsp-server/src/main/java/org/xipki/ocsp/server/OcspServerImpl.java
+++ b/ocsp-server/src/main/java/org/xipki/ocsp/server/OcspServerImpl.java
@@ -71,26 +71,6 @@ import static org.xipki.util.Args.notNull;
 
 public class OcspServerImpl implements OcspServer {
 
-  private static class SizeComparableString implements Comparable<SizeComparableString> {
-
-    private final String str;
-
-    public SizeComparableString(String str) {
-      this.str = notNull(str, "str");
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      return obj instanceof SizeComparableString ? str.contentEquals(((SizeComparableString) obj).str) : false;
-    }
-
-    @Override
-    public int compareTo(SizeComparableString obj) {
-      return (str.length() == obj.str.length()) ? 0 : (str.length() > obj.str.length()) ? 1 : -1;
-    }
-
-  } // class SizeComparableString
-
   private static class OcspRespControl {
     boolean canCacheInfo;
     boolean includeExtendedRevokeExtension;
@@ -496,27 +476,23 @@ public class OcspServerImpl implements OcspServer {
     } // end for
 
     // servlet paths
-    List<SizeComparableString> tmpList = new LinkedList<>();
+    List<String> tmpList = new LinkedList<>();
     for (Entry<String, ResponderOption> entry : responderOptions.entrySet()) {
       String name = entry.getKey();
       ResponderImpl responder = responders.get(name);
       ResponderOption option = entry.getValue();
       List<String> strs = option.getServletPaths();
       for (String path : strs) {
-        tmpList.add(new SizeComparableString(path));
+        tmpList.add(path);
         path2responderMap.put(path, responder);
       }
     }
 
     // Sort the servlet paths according to the length of path. The first one is the
     // longest, and the last one is the shortest.
-    Collections.sort(tmpList);
-    List<String> list2 = new ArrayList<>(tmpList.size());
-    for (SizeComparableString m : tmpList) {
-      list2.add(m.str);
-    }
+    Collections.sort(tmpList, (o1, o2) -> o2.length() - o1.length());
     this.servletPaths.clear();
-    this.servletPaths.addAll(list2);
+    this.servletPaths.addAll(tmpList);
   } // method init0
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <repository>
       <id>apache-snapshots</id>
       <name>Apache Snapshots Repository</name>
-      <url>http://repository.apache.org/content/groups/snapshots-group</url>
+      <url>https://repository.apache.org/content/groups/snapshots-group</url>
       <releases>
         <enabled>false</enabled>
       </releases>


### PR DESCRIPTION
The `servletPaths` in `OcspServerImpl` are not sorted according to the stated comment (longest path first).

This leads to `OcspServerImpl.getResponderForPath(...)` to always pick e.g. responder for `/` since it is sorted at the top of the list and therefore chosen.

Along with fixing, the handling was simplified.

Note: Waiting for build issues to be fixed before converting from draft PR to real PR, see https://github.com/xipki/xipki/issues/270.