### PR TITLE
Changed out default Java Properties file usage for PropertiesConfigation to support using environment variables for container deployment

### DIFF
--- a/ca-mgmt-client/src/main/java/org/xipki/ca/mgmt/db/DbToolBase.java
+++ b/ca-mgmt-client/src/main/java/org/xipki/ca/mgmt/db/DbToolBase.java
@@ -3,6 +3,8 @@
 
 package org.xipki.ca.mgmt.db;
 
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xipki.datasource.DataAccessException;
@@ -15,7 +17,6 @@ import org.xipki.util.StringUtil;
 import java.io.*;
 import java.nio.file.Files;
 import java.sql.*;
-import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.Deflater;
 import java.util.zip.ZipOutputStream;
@@ -196,8 +197,8 @@ public class DbToolBase implements Closeable {
     ps.setInt(index, value ? 1 : 0);
   }
 
-  public static Properties getDbConfProperties(InputStream is) throws IOException {
-    Properties props = new Properties();
+  public static PropertiesConfiguration getDbConfProperties(InputStream is) throws ConfigurationException {
+    PropertiesConfiguration props = new PropertiesConfiguration();
     try {
       props.load(is);
     } finally {

--- a/ca-mgmt-client/src/main/java/org/xipki/ca/mgmt/db/DbWorker.java
+++ b/ca-mgmt-client/src/main/java/org/xipki/ca/mgmt/db/DbWorker.java
@@ -3,6 +3,8 @@
 
 package org.xipki.ca.mgmt.db;
 
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xipki.ca.mgmt.db.port.DbPorter;
@@ -15,7 +17,6 @@ import org.xipki.util.IoUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -36,8 +37,8 @@ public abstract class DbWorker implements Runnable {
   private Exception exception;
 
   public DbWorker(DataSourceFactory datasourceFactory, PasswordResolver passwordResolver, String dbConfFile)
-          throws PasswordResolverException, IOException {
-    Properties props = DbPorter.getDbConfProperties(Files.newInputStream(Paths.get(IoUtil.expandFilepath(dbConfFile))));
+          throws PasswordResolverException, IOException, ConfigurationException {
+    PropertiesConfiguration props = DbPorter.getDbConfProperties(Files.newInputStream(Paths.get(IoUtil.expandFilepath(dbConfFile))));
     this.datasource = datasourceFactory.createDataSource("ds-" + dbConfFile, props, passwordResolver);
   }
 

--- a/ca-mgmt-client/src/main/java/org/xipki/ca/mgmt/db/diffdb/DigestDiffWorker.java
+++ b/ca-mgmt-client/src/main/java/org/xipki/ca/mgmt/db/diffdb/DigestDiffWorker.java
@@ -3,6 +3,8 @@
 
 package org.xipki.ca.mgmt.db.diffdb;
 
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xipki.ca.mgmt.db.DbWorker;
@@ -20,7 +22,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Clock;
-import java.util.Properties;
 import java.util.Set;
 
 /**
@@ -50,7 +51,7 @@ public class DigestDiffWorker extends DbWorker {
       DataSourceFactory datasourceFactory, PasswordResolver passwordResolver,
       boolean revokedOnly, String refDbConfFile, String targetDbConfFile, String reportDirName,
       int numCertsPerSelect, int numThreads, Set<byte[]> includeCaCerts)
-      throws PasswordResolverException, IOException {
+          throws PasswordResolverException, IOException, ConfigurationException {
     super(datasourceFactory, passwordResolver, refDbConfFile);
     this.reportDir = reportDirName;
     this.numThreads = Args.positive(numThreads, "numThreads");
@@ -76,7 +77,7 @@ public class DigestDiffWorker extends DbWorker {
       throw new IOException(reportDirName + " is not empty");
     }
 
-    Properties props = DbPorter.getDbConfProperties(
+    PropertiesConfiguration props = DbPorter.getDbConfProperties(
         Files.newInputStream(Paths.get(IoUtil.expandFilepath(targetDbConfFile))));
     this.targetDatasource = datasourceFactory.createDataSource("ds-" + targetDbConfFile, props, passwordResolver);
   } // constructor

--- a/ca-mgmt-client/src/main/java/org/xipki/ca/mgmt/db/port/DbPortWorker.java
+++ b/ca-mgmt-client/src/main/java/org/xipki/ca/mgmt/db/port/DbPortWorker.java
@@ -9,6 +9,8 @@ import net.lingala.zip4j.model.FileHeader;
 import net.lingala.zip4j.model.ZipParameters;
 import net.lingala.zip4j.model.enums.AesKeyStrength;
 import net.lingala.zip4j.model.enums.EncryptionMethod;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xipki.ca.mgmt.db.DbWorker;
@@ -29,7 +31,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Clock;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Properties;
 
 /**
  * Worker for database export / import.
@@ -46,7 +47,7 @@ public abstract class DbPortWorker extends DbWorker {
 
   public DbPortWorker(DataSourceFactory datasourceFactory, PasswordResolver passwordResolver,
                       String dbConfFile, char[] password)
-      throws PasswordResolverException, IOException {
+          throws PasswordResolverException, IOException, ConfigurationException {
     super(datasourceFactory, passwordResolver, dbConfFile);
     this.password = password;
   }
@@ -146,13 +147,13 @@ public abstract class DbPortWorker extends DbWorker {
     public ImportCaDb(DataSourceFactory datasourceFactory, PasswordResolver passwordResolver,
                       String caConfDbFile, String caDbFile,
                       boolean resume, String srcFolder, int batchEntriesPerCommit, char[] password)
-        throws PasswordResolverException, IOException {
+            throws PasswordResolverException, IOException, ConfigurationException {
       super(datasourceFactory, passwordResolver, (caConfDbFile == null ? caDbFile : caConfDbFile), password);
       this.resume = resume;
       this.srcFolder = IoUtil.expandFilepath(srcFolder);
       this.batchEntriesPerCommit = batchEntriesPerCommit;
 
-      Properties props = DbPorter.getDbConfProperties(Files.newInputStream(
+      PropertiesConfiguration props = DbPorter.getDbConfProperties(Files.newInputStream(
                             Paths.get(IoUtil.expandFilepath(caDbFile))));
       this.caDataSource = datasourceFactory.createDataSource("ds-" + caDbFile,
                             props, passwordResolver);
@@ -231,7 +232,7 @@ public abstract class DbPortWorker extends DbWorker {
     public ExportCaDb(
         DataSourceFactory datasourceFactory, PasswordResolver passwordResolver, String caConfDbFile, String caDbFile,
         String destFolder, boolean resume, int numCertsInBundle, int numCertsPerSelect, char[] password)
-        throws PasswordResolverException, IOException {
+            throws PasswordResolverException, IOException, ConfigurationException {
       super(datasourceFactory, passwordResolver, caConfDbFile != null ? caConfDbFile : caDbFile, password);
       this.destFolder = IoUtil.expandFilepath(destFolder);
       this.resume = resume;
@@ -239,7 +240,7 @@ public abstract class DbPortWorker extends DbWorker {
       this.numCertsPerSelect = numCertsPerSelect;
       checkDestFolder();
 
-      Properties props = DbPorter.getDbConfProperties(Files.newInputStream(
+      PropertiesConfiguration props = DbPorter.getDbConfProperties(Files.newInputStream(
           Paths.get(IoUtil.expandFilepath(caDbFile))));
       this.caDataSource = datasourceFactory.createDataSource("ds-" + caDbFile,
           props, passwordResolver);
@@ -322,7 +323,7 @@ public abstract class DbPortWorker extends DbWorker {
     public ExportOcspDb(
         DataSourceFactory datasourceFactory, PasswordResolver passwordResolver, String dbConfFile,
         String destFolder, boolean resume, int numCertsInBundle, int numCertsPerSelect, char[] password)
-        throws PasswordResolverException, IOException {
+            throws PasswordResolverException, IOException, ConfigurationException {
       super(datasourceFactory, passwordResolver, dbConfFile, password);
 
       this.destFolder = Args.notBlank(destFolder, destFolder);
@@ -391,7 +392,7 @@ public abstract class DbPortWorker extends DbWorker {
     public ImportOcspDb(
         DataSourceFactory datasourceFactory, PasswordResolver passwordResolver, String dbConfFile,
         boolean resume, String srcFolder, int batchEntriesPerCommit, char[] password)
-        throws PasswordResolverException, IOException {
+            throws PasswordResolverException, IOException, ConfigurationException {
       super(datasourceFactory, passwordResolver, dbConfFile, password);
       this.resume = resume;
       this.srcFolder = IoUtil.expandFilepath(srcFolder);
@@ -441,7 +442,7 @@ public abstract class DbPortWorker extends DbWorker {
     public ImportOcspFromCaDb(
         DataSourceFactory datasourceFactory, PasswordResolver passwordResolver, String dbConfFile,
         String publisherName, boolean resume, String srcFolder, int batchEntriesPerCommit, char[] password)
-        throws PasswordResolverException, IOException {
+            throws PasswordResolverException, IOException, ConfigurationException {
       super(datasourceFactory, passwordResolver, dbConfFile, password);
       this.publisherName = publisherName;
       this.resume = resume;

--- a/shells/ca-mgmt-shell/src/main/java/org/xipki/ca/mgmt/shell/DbActions.java
+++ b/shells/ca-mgmt-shell/src/main/java/org/xipki/ca/mgmt/shell/DbActions.java
@@ -3,6 +3,7 @@
 
 package org.xipki.ca.mgmt.shell;
 
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.Completion;
@@ -31,7 +32,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -187,7 +187,7 @@ public class DbActions {
 
     @Override
     protected Object execute0() throws Exception {
-      Properties props = new Properties();
+      PropertiesConfiguration props = new PropertiesConfiguration();
       try (InputStream is = Files.newInputStream(Paths.get(IoUtil.expandFilepath(dbConfFile)))) {
         props.load(is);
       }


### PR DESCRIPTION
In order to deploy this via a docker container, it is usually necessary to pass in things such as DB passwords as ENV vars. This just switches things over to using PropertiesConfiguration, which is already provided as part of Tomcat so that environment variables can be specified within the properties files using variable interpolation, eg: `someprop=${env:DB_PASSWORD}`

Related commons PR: https://github.com/xipki/commons/pull/1